### PR TITLE
Fix for Path on unix based systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ From the command line, run the following commands to launch the application:
 
 ```
 git clone https://github.com/razor85/FenrirScreenshotManager.git
+cd FenrirScreenshotManager
 pip install -r requirements.txt 
 python fenrirScreenshotManager.py
 ```

--- a/fenrirScreenshotManager.py
+++ b/fenrirScreenshotManager.py
@@ -70,7 +70,7 @@ class SelectFolderWindow(select_folder_base, select_folder_form):
 
   def done(self, ret_code):
     path = self.directoryEdit.text()
-    screenshots = Path(path) / Path('/screenshots')
+    screenshots = Path(path) / Path('screenshots')
     if not screenshots.exists() and ret_code != 0:
       msg = 'Invalid SD card path, \'{}\' directory not found. Create it and continue?'
       answer = QMessageBox.question(None, 'Screenshots not found',


### PR DESCRIPTION
Fixing paths so it is compatible with POSIX implementation.

While running the application on MacOS the path was being resolved to '`/screenshots'` the the additional forward slash, I think this is more permissive on WindowsPath implementation. After the change, I've also tested on Windows to ensure it didn't break.

Small change on the doc to ensure a clean copy and paste from the README to the terminal window.